### PR TITLE
Fix unclosed parenthesis in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `bracket_sets` method in `src/sqlfluff/core/dialects/base.py`. The method had an unclosed parenthesis in the `return` statement which was causing mypy and mypyc to fail.

## Changes

- Fixed the incomplete return statement in the `bracket_sets` method by adding `self._sets[label]` and closing the parenthesis.

## Related Issues

This fixes the CI build failure in workflow run #15404438438.

## Testing

The fix ensures that mypy type checking passes successfully.