### PR TITLE
Fix syntax error in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `bracket_sets` method implementation in `src/sqlfluff/core/dialects/base.py`. The issue was an unclosed parenthesis in the return statement.

## Changes

- Fixed the incomplete return statement in the `bracket_sets` method by adding the second argument to the `cast()` function and closing the parenthesis.

## Root Cause

The error was causing mypy and mypyc type checking to fail with the error `error: '(' was never closed [syntax]`. This was preventing the CI/CD pipeline from completing successfully.

The fix completes the return statement to properly cast and return the bracket sets.