### PR TITLE
Fix syntax error in dialects/base.py causing mypy and mypyc failures

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description
Fix syntax error in the `bracket_sets` method of the `Dialect` class in the dialect base module.

## Issue
The GitHub Actions workflow was failing with the following error:
```
.tox/mypy/lib/python3.10/site-packages/sqlfluff/core/dialects/base.py:121: error: '(' was never closed [syntax]
```

## Fix
The issue was an incomplete `cast()` function call that was missing its second argument and closing parenthesis. 
This PR completes the statement by adding the missing second argument `self._sets[label]` and the closing parenthesis.

## Testing
This fix should resolve both the `mypy` and `mypyc` checks that were previously failing in CI.