### PR TITLE
Fix syntax error in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `bracket_sets` method in `src/sqlfluff/core/dialects/base.py`. The method had an incomplete `return` statement with a missing closing parenthesis and the second argument to the `cast()` function.

## Issue Fixed

The mypy check was failing with the following error:
```
.tox/mypy/lib/python3.10/site-packages/sqlfluff/core/dialects/base.py:121: error: '(' was never closed  [syntax]
```

## Fix

The fix completes the `cast()` function call by adding the second argument (`self._sets[label]`) and the closing parenthesis.