### PR TITLE
Fix unclosed parenthesis in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes an unclosed parenthesis in the `bracket_sets` method of the `Dialect` class in `src/sqlfluff/core/dialects/base.py`. 

The issue was causing the `mypy` and `mypyc` tasks to fail because of a syntax error in the code. This fix completes the return statement by properly closing the parenthesis and adding the return value.

The fixed code now correctly returns the cast bracket pair set from `self._sets[label]`.