### PR TITLE
Fix syntax error in bracket_sets method of Dialect class

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes a syntax error in the `bracket_sets` method of the `Dialect` class in SQLFluff's core dialect base.

## Issue
The method had an incomplete `cast()` function call which was missing its second argument and closing parenthesis. This caused mypy and mypyc to fail with the error: `'(' was never closed [syntax]`

## Fix
The fix completes the statement by adding the second argument to the cast function (`self._sets[label]`) and the closing parenthesis. This implementation follows the pattern used in the similar `sets()` method defined above it.