### PR TITLE
Fix syntax error in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the `bracket_sets` method of the `Dialect` class in `src/sqlfluff/core/dialects/base.py`.

## Issue
The `cast()` function call on line 121 was incomplete, missing its second argument and the closing parenthesis. This was causing mypy to fail with a syntax error: `'(' was never closed [syntax]`.

## Fix
Added the missing second argument to the `cast()` function call and added the closing parenthesis.

Before:
```python
return cast(set[BracketPairTuple],
```

After:
```python
return cast(set[BracketPairTuple], self._sets[label])
```

This fix allows the mypy and mypyc checks to pass successfully.