### PR TITLE
Fix syntax error in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
Fix syntax error in the bracket_sets method of the Dialect class

## Issue
There was a syntax error in the `bracket_sets` method of the `Dialect` class in `src/sqlfluff/core/dialects/base.py`. The `cast()` function call was incomplete, missing both its second parameter and closing parenthesis.

## Fix
- Added the missing second parameter `self._sets[label]` to the `cast()` function
- Added the closing parenthesis to complete the function call

This fix resolves the mypy and mypyc failures in the CI workflow.