### PR TITLE
Fix syntax error in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the `bracket_sets` method in `src/sqlfluff/core/dialects/base.py`. The issue was an incomplete Python syntax statement with a missing second argument and closing parenthesis in the `cast()` function call.

## Changes
- Completed the `return cast()` statement by adding the missing second argument `self._sets[label]` and closing parenthesis
- This fixes the mypy error: `'(' was never closed [syntax]` reported during CI builds

## Testing
The fix allows mypy type checking to pass successfully without syntax errors.