### PR TITLE
Fix incomplete return statement in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,8 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        # Return properly cast set
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `bracket_sets` method of the `Dialect` class in `src/sqlfluff/core/dialects/base.py`. The issue was an incomplete statement with an opening parenthesis that was not properly closed.

## Changes

* Completed the `return cast(set[BracketPairTuple], ...)` statement by adding the missing second argument (`self._sets[label]`) and the closing parenthesis.
* Added a comment to clarify the purpose of the return statement.

## Root Cause

The error was occurring during the mypy type checking process with the message: "error: '(' was never closed [syntax]", which prevented the CI workflow from completing successfully. The `return` statement was incomplete, missing the second argument to the `cast()` function and the closing parenthesis.

## Test Results

This fix should allow mypy type checking to complete successfully and fix the failed GitHub Actions workflow.