### PR TITLE
Fix syntax error: missing closing parenthesis in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `bracket_sets` method of the `Dialect` class. The method was missing a closing parenthesis and the value to be cast.

## Issue

The CI pipeline was failing with the following error:
```
sqlfluff/core/dialects/base.py:121: error: '(' was never closed [syntax]
```

## Fix

Completed the return statement by adding the closing parenthesis and the value to be cast.

From:
```python
return cast(set[BracketPairTuple],
```

To:
```python
return cast(set[BracketPairTuple], self._sets[label])
```

This ensures that the method correctly returns the appropriate set cast to the expected type.