### PR TITLE
Fix syntax error in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the `bracket_sets` method in `sqlfluff/core/dialects/base.py`. The return statement was incomplete with an opening parenthesis but no closing parenthesis and no object being cast.

## Issue
The workflow failed with the following error:
```
.tox/mypy/lib/python3.10/site-packages/sqlfluff/core/dialects/base.py:121: error: '(' was never closed  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

## Solution
The fix completes the return statement by adding `self._sets[label]` as the object to be cast and closing the parenthesis.

## Test Plan
The PR should pass the CI checks that were failing previously, specifically the mypy and mypyc tests.