### PR TITLE
Fix syntax error in Dialect.bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Issue

The GitHub Actions CI workflow fails during the mypy type checking step because of a syntax error in `src/sqlfluff/core/dialects/base.py` at line 121. 

The error message indicates: "error: '(' was never closed [syntax]".

## Root Cause

In the `bracket_sets` method of the `Dialect` class, the `cast()` function call is incomplete. The line reads:

```python
return cast(set[BracketPairTuple],
```

It's missing the second argument to the `cast()` function (the value to be cast) and the closing parenthesis.

## Solution

This PR completes the `cast()` function call by adding the missing second argument (`self._sets[label]`) and the closing parenthesis:

```python
return cast(set[BracketPairTuple], self._sets[label])
```

This fix ensures proper typing for the return value while maintaining the intended behavior of the method.